### PR TITLE
Patchcodeverifier

### DIFF
--- a/src/OAuthClient.php
+++ b/src/OAuthClient.php
@@ -234,10 +234,12 @@ class OAuthClient
             'grant_type' => 'authorization_code',
             'code' => $responseCode,
             'redirect_uri' => $sessionData['redirect_uri'],
-            // 'code_verifier' => $sessionData['code_verifier'],
         ];
 
-        // fail-safe error handling
+        /* 
+        ** code_verifier does not exist in some occasions.
+        ** This block fixes that issue.
+        */
         if ( isset($sessionData['code_verifier']) ) {
             $tokenRequestData['code_verifier'] = $sessionData['code_verifier'];
         }

--- a/src/OAuthClient.php
+++ b/src/OAuthClient.php
@@ -234,8 +234,13 @@ class OAuthClient
             'grant_type' => 'authorization_code',
             'code' => $responseCode,
             'redirect_uri' => $sessionData['redirect_uri'],
-            'code_verifier' => $sessionData['code_verifier'],
+            // 'code_verifier' => $sessionData['code_verifier'],
         ];
+
+        // fail-safe error handling
+        if ( isset($sessionData['code_verifier']) ) {
+            $tokenRequestData['code_verifier'] = $sessionData['code_verifier'];
+        }
 
         $response = $this->httpClient->send(
             Request::post(


### PR DESCRIPTION
In our experience, "code_verifier" is not always included in the api response while creating tokens. Thus, we add this block of code to check the existence of such key pair